### PR TITLE
1.0.1

### DIFF
--- a/ClientPlugin/Properties/AssemblyInfo.cs
+++ b/ClientPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]


### PR DESCRIPTION
- Compatibility with the Shift-F11 statistics overlay
- Compatibility with the FPS Counter plugin, which has an `FPSOverlay` screen class

More such issues may follow, because the detection of valid in-game screens (which are not just debug overlays) cannot be solved in general. This is because Keen (in their infinite wisdom) subclassed a lot of valid in-game screens from `MyGuiScreenDebugBase`...