### PR TITLE
1.1.1

### DIFF
--- a/ClientPlugin/Logic/Logic.cs
+++ b/ClientPlugin/Logic/Logic.cs
@@ -564,6 +564,7 @@ namespace ClientPlugin.Logic
                 return;
 
             var gridBuilder = CreateGridBuilder(includeIntersectingBlocks);
+            MyEntities.RemapObjectBuilder(gridBuilder);
 
             // Calculation copied from MyGuiBlueprintScreen_Reworked.CopyBlueprintPrefabToClipboard
             BoundingSphere boundingSphere = gridBuilder.CalculateBoundingSphere();
@@ -586,6 +587,7 @@ namespace ClientPlugin.Logic
         private void SaveToBlueprintFile(bool includeIntersectingBlocks)
         {
             var gridBuilder = CreateGridBuilder(includeIntersectingBlocks);
+            MyEntities.RemapObjectBuilder(gridBuilder);
 
             if (!Cfg.RenameBlueprint)
             {

--- a/ClientPlugin/Properties/AssemblyInfo.cs
+++ b/ClientPlugin/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]

--- a/README.md
+++ b/README.md
@@ -126,12 +126,13 @@ The configuration can be changed anytime without having to restart the game.
 
 ![Configuration](doc/ConfigDialog.png "Config Dialog")
 
-## Limitations
+## Known issues and limitations
 
-- The selection box can cover blocks and operate only on a single grid.
-- Sections can store blocks from a single grid only (without subgrids).
-- Pasting sections with disconnected blocks works as expected, but may result in "floating" blocks.
-- The plugin is largely untested in survival and should **not** be used in multiplayer.
+- **Subgrids are not copied**, they're left behind, currently. It is a known issue and may be solved later.
+- **Blocks assigned to any toolbars** (cockpits, timers, etc) **or added to Event/Turret Controller block lists get disconnected** if they end up on separate grids. It may be solved later, this is a non-trivial known issue with grid splits.
+- The **selection box** can cover blocks and operate only on a **single grid**. This is normal and likely won't change.
+- Pasting sections with disconnected blocks works as expected, but may result in "floating" blocks. This is normal and by design to allow for some building tricks. Play with it!
+- This plugin is largely untested in survival (only with creative mode tools enabled) and is disabled in multiplayer (even if you're an admin). It should work if you're playing on the server of a "Friends" multiplayer game, but this mode has note been tested.
 
 ## Troubleshooting
 


### PR DESCRIPTION
- Documented known issues and limitations
- Remapped the grid builders to avoid possible `EntityId` collisions